### PR TITLE
Fixed for 'NAN' was not declared

### DIFF
--- a/SHT31.cpp
+++ b/SHT31.cpp
@@ -1,4 +1,5 @@
 #include "SHT31.h"
+#include <math.h>
 
 SHT31::SHT31() {
 }


### PR DESCRIPTION
Add `math.h` include.
On some board platforms, there was a NAN not declared error due to the lack of `math.h`.

**Error Log**
```
Grove_SHT31_Temp_Humi_Sensor/SHT31.cpp:16:30: error: 'NAN' was not declared in this scope
   if (! getTempHum()) return NAN;
                              ^~~
Grove_SHT31_Temp_Humi_Sensor/SHT31.cpp:22:30: error: 'NAN' was not declared in this scope
   if (! getTempHum()) return NAN;
                              ^~~
```